### PR TITLE
Update adding-snabbdom.md

### DIFF
--- a/book/vdom/adding-snabbdom.md
+++ b/book/vdom/adding-snabbdom.md
@@ -15,7 +15,7 @@ In this project, I've chosen to use [snabbdom](https://github.com/snabbdom/snabb
 Using `npm` or `yarn`:
 
 ```
-$ yarn install snabbdom
+$ yarn add snabbdom
 ```
 
 ## Delegate the DOM manipulations to snabbdom


### PR DESCRIPTION
 `install` has been replaced with `add` to add new dependencies. Run "yarn add snabbdom" instead.